### PR TITLE
Mask NRIC/ID for privacy in reports and exports

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -68,6 +68,21 @@ export function FileUpload({ onFileUpload, isDarkMode = false }: FileUploadProps
           <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'} font-body`}>
             Supports CSV files with DSA student data format
           </p>
+          <div className={`mt-4 p-3 rounded-lg ${isDarkMode ? 'bg-blue-900/20 border border-blue-700' : 'bg-blue-50 border border-blue-200'}`}>
+            <div className="flex items-start gap-2">
+              <svg className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+              </svg>
+              <div className="text-left">
+                <p className={`text-xs font-medium ${isDarkMode ? 'text-blue-300' : 'text-blue-700'} font-body`}>
+                  Privacy Notice
+                </p>
+                <p className={`text-xs ${isDarkMode ? 'text-blue-200' : 'text-blue-600'} font-body`}>
+                  NRIC/ID numbers are automatically masked for privacy. Original data is not stored or retrievable.
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/StudentReport.tsx
+++ b/src/components/StudentReport.tsx
@@ -59,8 +59,19 @@ export function StudentReport({ student, onGeneratePDF, onGenerateHTML, isDarkMo
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-3">
               <div>
-                <label className={`text-sm font-medium ${isDarkMode ? 'text-gray-400' : 'text-gray-500'} font-body`}>NRIC/ID</label>
-                <p className={`${isDarkMode ? 'text-white' : 'text-gray-900'} font-body`}>{student.id}</p>
+                <div className="flex items-center gap-2 mb-1">
+                  <label className={`text-sm font-medium ${isDarkMode ? 'text-gray-400' : 'text-gray-500'} font-body`}>NRIC/ID</label>
+                  <div className="group relative">
+                    <svg className="w-4 h-4 text-gray-400 cursor-help" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                    </svg>
+                    <div className={`absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 text-xs rounded-lg shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 max-w-xs ${isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-gray-900 text-white'}`}>
+                      NRIC/ID is masked for privacy. Original data is not stored or retrievable.
+                      <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800 dark:border-t-gray-800"></div>
+                    </div>
+                  </div>
+                </div>
+                <p className={`${isDarkMode ? 'text-white' : 'text-gray-900'} font-body font-mono`}>{student.id}</p>
               </div>
               <div>
                 <label className={`text-sm font-medium ${isDarkMode ? 'text-gray-400' : 'text-gray-500'} font-body`}>Primary School</label>

--- a/src/utils/bulkExport.ts
+++ b/src/utils/bulkExport.ts
@@ -3,154 +3,154 @@ import { generateHTMLReport } from './reportGenerator';
 import * as XLSX from 'xlsx';
 
 export function generateBulkExcel(students: Student[]): void {
-  const workbook = XLSX.utils.book_new();
-  
-  // Create summary sheet
-  const summaryData = students.map(student => ({
-    'NRIC/ID': student.id,
-    'Name': student.name,
-    'Primary School': student.primarySchool,
-    'Primary Talent': student.talent1,
-    'Secondary Talent': student.talent2 || '',
-    'Citizenship': student.citizenship,
-    'Date of Birth': student.dateOfBirth,
-    'Gender': student.sex,
-    'GEP Status': student.gepStatus || 'No',
-    'P6 Overall %': student.academics.p6.overallPercentage,
-    'P5 Overall %': student.academics.p5.overallPercentage,
-    'Main Contact': student.mainContact.name,
-    'Main Contact Mobile': student.mainContact.mobile,
-    'Main Contact Email': student.mainContact.email,
-    'Address': student.address,
-    'Postal Code': student.postalCode,
-    'NAPFA Award': student.napfa.award || '',
-    'Recommendation': student.recommendationReason || ''
-  }));
-  
-  const summarySheet = XLSX.utils.json_to_sheet(summaryData);
-  XLSX.utils.book_append_sheet(workbook, summarySheet, 'Student Summary');
-  
-  // Create detailed academic sheet
-  const academicData = students.map(student => ({
-    'NRIC/ID': student.id,
-    'Name': student.name,
-    'P6 Overall %': student.academics.p6.overallPercentage,
-    'P6 English': student.academics.p6.subjects.english.score,
-    'P6 Mathematics': student.academics.p6.subjects.maths.score,
-    'P6 Science': student.academics.p6.subjects.science.score,
-    'P6 Mother Tongue': student.academics.p6.subjects.motherTongue.score,
-    'P6 Conduct': student.academics.p6.conduct,
-    'P6 Teacher Remarks': student.academics.p6.teacherRemarks,
-    'P5 Overall %': student.academics.p5.overallPercentage,
-    'P5 English': student.academics.p5.subjects.english.score,
-    'P5 Mathematics': student.academics.p5.subjects.maths.score,
-    'P5 Science': student.academics.p5.subjects.science.score,
-    'P5 Mother Tongue': student.academics.p5.subjects.motherTongue.score,
-    'P5 Conduct': student.academics.p5.conduct,
-    'P5 Teacher Remarks': student.academics.p5.teacherRemarks
-  }));
-  
-  const academicSheet = XLSX.utils.json_to_sheet(academicData);
-  XLSX.utils.book_append_sheet(workbook, academicSheet, 'Academic Records');
-  
-  // Create CCA activities sheet
-  const ccaData: any[] = [];
-  students.forEach(student => {
-    student.ccaActivities.forEach(cca => {
-      ccaData.push({
-        'NRIC/ID': student.id,
+    const workbook = XLSX.utils.book_new();
+
+    // Create summary sheet
+    const summaryData = students.map(student => ({
+        'NRIC/ID (Masked)': student.id,
         'Name': student.name,
-        'Year': cca.year,
-        'CCA Name': cca.name,
-        'Event': cca.event,
-        'Involvement': cca.involvement
-      });
-    });
-  });
-  
-  if (ccaData.length > 0) {
-    const ccaSheet = XLSX.utils.json_to_sheet(ccaData);
-    XLSX.utils.book_append_sheet(workbook, ccaSheet, 'CCA Activities');
-  }
-  
-  // Create VIA activities sheet
-  const viaData: any[] = [];
-  students.forEach(student => {
-    student.viaActivities.forEach(via => {
-      viaData.push({
-        'NRIC/ID': student.id,
+        'Primary School': student.primarySchool,
+        'Primary Talent': student.talent1,
+        'Secondary Talent': student.talent2 || '',
+        'Citizenship': student.citizenship,
+        'Date of Birth': student.dateOfBirth,
+        'Gender': student.sex,
+        'GEP Status': student.gepStatus || 'No',
+        'P6 Overall %': student.academics.p6.overallPercentage,
+        'P5 Overall %': student.academics.p5.overallPercentage,
+        'Main Contact': student.mainContact.name,
+        'Main Contact Mobile': student.mainContact.mobile,
+        'Main Contact Email': student.mainContact.email,
+        'Address': student.address,
+        'Postal Code': student.postalCode,
+        'NAPFA Award': student.napfa.award || '',
+        'Recommendation': student.recommendationReason || ''
+    }));
+
+    const summarySheet = XLSX.utils.json_to_sheet(summaryData);
+    XLSX.utils.book_append_sheet(workbook, summarySheet, 'Student Summary');
+
+    // Create detailed academic sheet
+    const academicData = students.map(student => ({
+        'NRIC/ID (Masked)': student.id,
         'Name': student.name,
-        'Year': via.year,
-        'VIA Activity': via.name,
-        'Partner': via.partner
-      });
+        'P6 Overall %': student.academics.p6.overallPercentage,
+        'P6 English': student.academics.p6.subjects.english.score,
+        'P6 Mathematics': student.academics.p6.subjects.maths.score,
+        'P6 Science': student.academics.p6.subjects.science.score,
+        'P6 Mother Tongue': student.academics.p6.subjects.motherTongue.score,
+        'P6 Conduct': student.academics.p6.conduct,
+        'P6 Teacher Remarks': student.academics.p6.teacherRemarks,
+        'P5 Overall %': student.academics.p5.overallPercentage,
+        'P5 English': student.academics.p5.subjects.english.score,
+        'P5 Mathematics': student.academics.p5.subjects.maths.score,
+        'P5 Science': student.academics.p5.subjects.science.score,
+        'P5 Mother Tongue': student.academics.p5.subjects.motherTongue.score,
+        'P5 Conduct': student.academics.p5.conduct,
+        'P5 Teacher Remarks': student.academics.p5.teacherRemarks
+    }));
+
+    const academicSheet = XLSX.utils.json_to_sheet(academicData);
+    XLSX.utils.book_append_sheet(workbook, academicSheet, 'Academic Records');
+
+    // Create CCA activities sheet
+    const ccaData: any[] = [];
+    students.forEach(student => {
+        student.ccaActivities.forEach(cca => {
+            ccaData.push({
+                'NRIC/ID (Masked)': student.id,
+                'Name': student.name,
+                'Year': cca.year,
+                'CCA Name': cca.name,
+                'Event': cca.event,
+                'Involvement': cca.involvement
+            });
+        });
     });
-  });
-  
-  if (viaData.length > 0) {
-    const viaSheet = XLSX.utils.json_to_sheet(viaData);
-    XLSX.utils.book_append_sheet(workbook, viaSheet, 'VIA Activities');
-  }
-  
-  // Create awards sheet
-  const awardsData: any[] = [];
-  students.forEach(student => {
-    student.awards.forEach(award => {
-      awardsData.push({
-        'NRIC/ID': student.id,
+
+    if (ccaData.length > 0) {
+        const ccaSheet = XLSX.utils.json_to_sheet(ccaData);
+        XLSX.utils.book_append_sheet(workbook, ccaSheet, 'CCA Activities');
+    }
+
+    // Create VIA activities sheet
+    const viaData: any[] = [];
+    students.forEach(student => {
+        student.viaActivities.forEach(via => {
+            viaData.push({
+                'NRIC/ID (Masked)': student.id,
+                'Name': student.name,
+                'Year': via.year,
+                'VIA Activity': via.name,
+                'Partner': via.partner
+            });
+        });
+    });
+
+    if (viaData.length > 0) {
+        const viaSheet = XLSX.utils.json_to_sheet(viaData);
+        XLSX.utils.book_append_sheet(workbook, viaSheet, 'VIA Activities');
+    }
+
+    // Create awards sheet
+    const awardsData: any[] = [];
+    students.forEach(student => {
+        student.awards.forEach(award => {
+            awardsData.push({
+                'NRIC/ID (Masked)': student.id,
+                'Name': student.name,
+                'Year': award.year,
+                'Award': award.name
+            });
+        });
+
+        student.nonSchoolAwards.forEach(award => {
+            awardsData.push({
+                'NRIC/ID (Masked)': student.id,
+                'Name': student.name,
+                'Year': 'N/A',
+                'Award': award
+            });
+        });
+    });
+
+    if (awardsData.length > 0) {
+        const awardsSheet = XLSX.utils.json_to_sheet(awardsData);
+        XLSX.utils.book_append_sheet(workbook, awardsSheet, 'Awards');
+    }
+
+    // Create NAPFA sheet
+    const napfaData = students.map(student => ({
+        'NRIC/ID (Masked)': student.id,
         'Name': student.name,
-        'Year': award.year,
-        'Award': award.name
-      });
-    });
-    
-    student.nonSchoolAwards.forEach(award => {
-      awardsData.push({
-        'NRIC/ID': student.id,
-        'Name': student.name,
-        'Year': 'N/A',
-        'Award': award
-      });
-    });
-  });
-  
-  if (awardsData.length > 0) {
-    const awardsSheet = XLSX.utils.json_to_sheet(awardsData);
-    XLSX.utils.book_append_sheet(workbook, awardsSheet, 'Awards');
-  }
-  
-  // Create NAPFA sheet
-  const napfaData = students.map(student => ({
-    'NRIC/ID': student.id,
-    'Name': student.name,
-    'Year': student.napfa.year,
-    'Height (cm)': student.napfa.height,
-    'Weight (kg)': student.napfa.weight,
-    'Sit-up Score': student.napfa.sitUp.score,
-    'Sit-up Band': student.napfa.sitUp.band,
-    'Standing Broad Jump Score': student.napfa.standingBroadJump.score,
-    'Standing Broad Jump Band': student.napfa.standingBroadJump.band,
-    'Sit & Reach Score': student.napfa.sitAndReach.score,
-    'Sit & Reach Band': student.napfa.sitAndReach.band,
-    'Pull-up Score': student.napfa.pullUp.score,
-    'Pull-up Band': student.napfa.pullUp.band,
-    'Shuttle Run Score': student.napfa.shuttleRun.score,
-    'Shuttle Run Band': student.napfa.shuttleRun.band,
-    'Run Score': student.napfa.run.score,
-    'Run Band': student.napfa.run.band,
-    'Award': student.napfa.award
-  }));
-  
-  const napfaSheet = XLSX.utils.json_to_sheet(napfaData);
-  XLSX.utils.book_append_sheet(workbook, napfaSheet, 'NAPFA Results');
-  
-  // Download the file
-  const fileName = `Student_Reports_${new Date().toISOString().split('T')[0]}.xlsx`;
-  XLSX.writeFile(workbook, fileName);
+        'Year': student.napfa.year,
+        'Height (cm)': student.napfa.height,
+        'Weight (kg)': student.napfa.weight,
+        'Sit-up Score': student.napfa.sitUp.score,
+        'Sit-up Band': student.napfa.sitUp.band,
+        'Standing Broad Jump Score': student.napfa.standingBroadJump.score,
+        'Standing Broad Jump Band': student.napfa.standingBroadJump.band,
+        'Sit & Reach Score': student.napfa.sitAndReach.score,
+        'Sit & Reach Band': student.napfa.sitAndReach.band,
+        'Pull-up Score': student.napfa.pullUp.score,
+        'Pull-up Band': student.napfa.pullUp.band,
+        'Shuttle Run Score': student.napfa.shuttleRun.score,
+        'Shuttle Run Band': student.napfa.shuttleRun.band,
+        'Run Score': student.napfa.run.score,
+        'Run Band': student.napfa.run.band,
+        'Award': student.napfa.award
+    }));
+
+    const napfaSheet = XLSX.utils.json_to_sheet(napfaData);
+    XLSX.utils.book_append_sheet(workbook, napfaSheet, 'NAPFA Results');
+
+    // Download the file
+    const fileName = `Student_Reports_${new Date().toISOString().split('T')[0]}.xlsx`;
+    XLSX.writeFile(workbook, fileName);
 }
 
 export function generateBulkHTML(students: Student[]): void {
-  const consolidatedHTML = `
+    const consolidatedHTML = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -315,8 +315,8 @@ export function generateBulkHTML(students: Student[]): void {
                     <h3 class="section-title">Basic Information</h3>
                     <div class="info-grid">
                         <div class="info-item">
-                            <div class="info-label">NRIC/ID</div>
-                            <div class="info-value">${student.id}</div>
+                            <div class="info-label">NRIC/ID <span style="font-size: 0.8em; color: #6b7280;">(masked for privacy)</span></div>
+                            <div class="info-value" style="font-family: monospace;">${student.id}</div>
                         </div>
                         <div class="info-item">
                             <div class="info-label">Date of Birth</div>
@@ -462,20 +462,20 @@ export function generateBulkHTML(students: Student[]): void {
 </body>
 </html>
   `;
-  
-  const blob = new Blob([consolidatedHTML], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `Consolidated_Student_Reports_${new Date().toISOString().split('T')[0]}.html`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+
+    const blob = new Blob([consolidatedHTML], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `Consolidated_Student_Reports_${new Date().toISOString().split('T')[0]}.html`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
 }
 
 export function generateBulkPDF(students: Student[]): void {
-  const consolidatedHTML = `
+    const consolidatedHTML = `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -755,15 +755,15 @@ export function generateBulkPDF(students: Student[]): void {
 </body>
 </html>
   `;
-  
-  const printWindow = window.open('', '_blank');
-  if (printWindow) {
-    printWindow.document.write(consolidatedHTML);
-    printWindow.document.close();
-    printWindow.focus();
-    
-    setTimeout(() => {
-      printWindow.print();
-    }, 1000);
-  }
+
+    const printWindow = window.open('', '_blank');
+    if (printWindow) {
+        printWindow.document.write(consolidatedHTML);
+        printWindow.document.close();
+        printWindow.focus();
+
+        setTimeout(() => {
+            printWindow.print();
+        }, 1000);
+    }
 }

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -1,16 +1,42 @@
 import { Student } from '../types/Student';
 
+// Function to mask NRIC/ID
+function maskNRIC(nric: string): string {
+  if (!nric || nric.trim() === '') return 'N/A';
+
+  // If it's already masked, return as is
+  if (nric.includes('*')) return nric;
+
+  // For NRIC format like T1234567X, mask to T****567X
+  if (nric.length >= 9) {
+    const prefix = nric.substring(0, 1);
+    const suffix = nric.substring(nric.length - 4);
+    return `${prefix}****${suffix}`;
+  }
+
+  // For other formats, mask all but first and last character
+  if (nric.length > 2) {
+    const first = nric.substring(0, 1);
+    const last = nric.substring(nric.length - 1);
+    const middle = '*'.repeat(nric.length - 2);
+    return `${first}${middle}${last}`;
+  }
+
+  // For very short IDs, just return asterisks
+  return '*'.repeat(nric.length);
+}
+
 export function parseCSV(csvContent: string): Student[] {
   const lines = csvContent.split('\n');
-  
+
   // Skip header lines (first 3 lines are metadata, 4th is column headers)
   const dataLines = lines.slice(4).filter(line => line.trim() && !line.startsWith('#'));
-  
+
   return dataLines.map((line, index) => {
     const columns = parseCSVLine(line);
-    
+
     return {
-      id: columns[0] || `student-${index}`,
+      id: maskNRIC(columns[0] || `student-${index}`),
       name: columns[1] || 'Unknown',
       primarySchool: columns[2] || '',
       talent1: columns[3] || '',
@@ -101,10 +127,10 @@ function parseCSVLine(line: string): string[] {
   const result: string[] = [];
   let current = '';
   let inQuotes = false;
-  
+
   for (let i = 0; i < line.length; i++) {
     const char = line[i];
-    
+
     if (char === '"') {
       inQuotes = !inQuotes;
     } else if (char === ',' && !inQuotes) {
@@ -114,7 +140,7 @@ function parseCSVLine(line: string): string[] {
       current += char;
     }
   }
-  
+
   result.push(current.trim());
   return result;
 }

--- a/src/utils/reportGenerator.ts
+++ b/src/utils/reportGenerator.ts
@@ -1,20 +1,20 @@
 import { Student } from '../types/Student';
 
 export function generateHTMLReport(student: Student): string {
-  const formatDate = (dateStr: string) => {
-    if (!dateStr) return 'N/A';
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-GB');
-  };
+    const formatDate = (dateStr: string) => {
+        if (!dateStr) return 'N/A';
+        const date = new Date(dateStr);
+        return date.toLocaleDateString('en-GB');
+    };
 
-  const getGradeColor = (score: number) => {
-    if (score >= 80) return '#10b981';
-    if (score >= 70) return '#3b82f6';
-    if (score >= 60) return '#f59e0b';
-    return '#ef4444';
-  };
+    const getGradeColor = (score: number) => {
+        if (score >= 80) return '#10b981';
+        if (score >= 70) return '#3b82f6';
+        if (score >= 60) return '#f59e0b';
+        return '#ef4444';
+    };
 
-  return `
+    return `
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -245,8 +245,8 @@ export function generateHTMLReport(student: Student): string {
             <h2 class="section-title">Basic Information</h2>
             <div class="info-grid">
                 <div class="info-item">
-                    <div class="info-label">NRIC/ID</div>
-                    <div class="info-value">${student.id}</div>
+                    <div class="info-label">NRIC/ID <span style="font-size: 0.8em; color: #6b7280;">(masked for privacy)</span></div>
+                    <div class="info-value" style="font-family: monospace;">${student.id}</div>
                 </div>
                 <div class="info-item">
                     <div class="info-label">Primary School</div>
@@ -517,28 +517,28 @@ export function generateHTMLReport(student: Student): string {
 }
 
 export function downloadHTML(content: string, filename: string) {
-  const blob = new Blob([content], { type: 'text/html' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+    const blob = new Blob([content], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
 }
 
 export function generatePDF(student: Student) {
-  const htmlContent = generateHTMLReport(student);
-  const printWindow = window.open('', '_blank');
-  if (printWindow) {
-    printWindow.document.write(htmlContent);
-    printWindow.document.close();
-    printWindow.focus();
-    
-    // Wait for content to load before printing
-    setTimeout(() => {
-      printWindow.print();
-    }, 1000);
-  }
+    const htmlContent = generateHTMLReport(student);
+    const printWindow = window.open('', '_blank');
+    if (printWindow) {
+        printWindow.document.write(htmlContent);
+        printWindow.document.close();
+        printWindow.focus();
+
+        // Wait for content to load before printing
+        setTimeout(() => {
+            printWindow.print();
+        }, 1000);
+    }
 }


### PR DESCRIPTION
BEFORE
users can accidentally upload NRIC
This isn't an issue since data isn't stored anyway but cleaning up for hygiene purposes

AFTER
Added masking for NRIC/ID fields throughout the application, including CSV parsing, Excel and HTML exports, and report generation. Updated UI components to indicate that NRIC/ID is masked for privacy and ensured all exports and displays use the masked version to enhance data privacy.

QOL for NRIC masking if user accidentally uploaded wholesale
<img width="733" height="397" alt="image" src="https://github.com/user-attachments/assets/9a9061fb-4dc2-4989-a5f1-d882dbacb3b2" />
